### PR TITLE
Always place the dummy window on correct screen on Wayland

### DIFF
--- a/src/dummy-window/dummy-window.js
+++ b/src/dummy-window/dummy-window.js
@@ -20,6 +20,11 @@ class DummyWindow {
     win.set_skip_taskbar_hint(true);
     win.set_skip_pager_hint(true);
     win.set_accept_focus(false);
+
+    const screen = Gdk.Screen.get_default();
+    const primaryScreen = screen.get_monitor_geometry(0);
+    const {x, y} = primaryScreen;
+    win.move(x + 100, y + 100);
     win.present();
   }
 


### PR DESCRIPTION
I am adding an extra config to locate primary screen's coordinates and place the dummy window within it, close to the top left corner.

At the time of my [original commit](https://github.com/marcinjahn/gnome-peek-top-bar-on-fullscreen-extension/commit/60334b0b8c497f5ea4e8ee911fc437ac0997ba7e) I did not have a Wayland multi-monitor setup. Once I did I noticed the dummy window not always spawning on the primary window and thus breaking this functionality. About half a year ago I have applied the fix I am committing now and it has been working fine for me all this time -- even when changing the primary screen on the go.