### PR TITLE
chore: support GNOME 47

### DIFF
--- a/resources/metadata.json
+++ b/resources/metadata.json
@@ -2,7 +2,7 @@
   "name": "Peek Top Bar on Fullscreen",
   "description": "Show the top bar (panel) on demand while having full screen content on (like a YouTube video). Just hover the mouse cursor to the top of the screen, and the panel will show up. This way, you can quickly check the time, or swich some toggles. This is similar to what macOS offers for full screen apps.\n\nThis extension is incompatible with Blur My Shell extension.",
   "uuid": "peek-top-bar-on-fullscreen@marcinjahn.com",
-  "shell-version": ["46"],
+  "shell-version": ["46", "47"],
   "url": "https://github.com/marcinjahn/gnome-peek-top-bar-on-fullscreen-extension",
-  "version": 14
+  "version": 15
 }


### PR DESCRIPTION
## Changes
- update `shell-version` to include 47 in `metadata.json`
- bump `version` to 15 in `metadata.json`

## Motivation
[GNOME 47](https://release.gnome.org/47) was released a while ago and this extension stopped working after I upgraded to Ubuntu 24.10 today.

I tried to run this extension locally with the contributing steps but failed to have it show up in extension manager to be able to test it properly. Therefore, please double check that this extension is indeed compatible with GNOME 47 out of the box without any further code changes.