### PR TITLE
Update metadata.json to support Gnome 48

### DIFF
--- a/resources/metadata.json
+++ b/resources/metadata.json
@@ -2,7 +2,7 @@
   "name": "Peek Top Bar on Fullscreen",
   "description": "Show the top bar (panel) on demand while having full screen content on (like a YouTube video). Just hover the mouse cursor to the top of the screen, and the panel will show up. This way, you can quickly check the time, or swich some toggles. This is similar to what macOS offers for full screen apps.\n\nThis extension is incompatible with Blur My Shell extension.",
   "uuid": "peek-top-bar-on-fullscreen@marcinjahn.com",
-  "shell-version": ["46", "47"],
+  "shell-version": ["46", "47", "48"],
   "url": "https://github.com/marcinjahn/gnome-peek-top-bar-on-fullscreen-extension",
-  "version": 15
+  "version": 16
 }


### PR DESCRIPTION
Simple update to support Gnome 48. It works well on my machine with Wayland, however I haven't looked in detail at the [porting guide](https://gjs.guide/extensions/upgrading/gnome-shell-48.html)

Closes #26 