### PR TITLE
Update metadata.json to support Gnome 49

### DIFF
--- a/resources/metadata.json
+++ b/resources/metadata.json
@@ -2,7 +2,7 @@
   "name": "Peek Top Bar on Fullscreen",
   "description": "Show the top bar (panel) on demand while having full screen content on (like a YouTube video). Just hover the mouse cursor to the top of the screen, and the panel will show up. This way, you can quickly check the time, or swich some toggles. This is similar to what macOS offers for full screen apps.\n\nThis extension is incompatible with Blur My Shell extension.",
   "uuid": "peek-top-bar-on-fullscreen@marcinjahn.com",
-  "shell-version": ["46", "47", "48"],
+  "shell-version": ["46", "47", "48", "49"],
   "url": "https://github.com/marcinjahn/gnome-peek-top-bar-on-fullscreen-extension",
-  "version": 17
+  "version": 18
 }


### PR DESCRIPTION
Fixes #28 

I have tested this on Ubuntu 25.10 (Gnome 49) and everything seems to work.

Also, I have taken a look at the [GNOME Shell 49 porting guide](https://gjs.guide/extensions/upgrading/gnome-shell-49.html) and to my understanding none of the changes seem to apply to this extension.

## Screencast for verification:

https://github.com/user-attachments/assets/1a3aa087-794f-4224-9d90-d5dbbca32950

